### PR TITLE
Register at startup

### DIFF
--- a/kp_registry/registry.py
+++ b/kp_registry/registry.py
@@ -28,7 +28,6 @@ class Registry():
 
     async def __aenter__(self):
         """Enter context."""
-        print(self.uri)
         if self.db is None:
             self.db = await aiosqlite.connect(self.uri)
             self.db.row_factory = sqlite3.Row

--- a/kp_registry/registry.py
+++ b/kp_registry/registry.py
@@ -28,6 +28,7 @@ class Registry():
 
     async def __aenter__(self):
         """Enter context."""
+        print(self.uri)
         if self.db is None:
             self.db = await aiosqlite.connect(self.uri)
             self.db.row_factory = sqlite3.Row

--- a/kp_registry/routers/kps.py
+++ b/kp_registry/routers/kps.py
@@ -47,6 +47,7 @@ async def register_endpoints(endpoints):
     }
     and registers them.  "url" is used to access meta_knowledge_graph, the others are used for logging
     """
+    LOGGER.info('register')
     async with httpx.AsyncClient() as client:
         responses = await asyncio.gather(
             *[
@@ -57,6 +58,7 @@ async def register_endpoints(endpoints):
         )
     meta_kgs = []
     for endpoint, response in zip(endpoints, responses):
+        LOGGER.info(endpoint)
         if isinstance(response, Exception):
             LOGGER.warning(
                 "Error accessing /meta_knowledge_graph for %s (https://smart-api.info/registry?q=%s): %s",
@@ -158,7 +160,7 @@ async def retrieve_kp_endpoints_from_smartapi():
                 _id,
             )
             continue
-        if component != "KP" and title != "BioThings Explorer ReasonerStdAPI":  # Special casing BTE.
+        if component != "KP":
             LOGGER.info(
                 "component != KP for %s (https://smart-api.info/registry?q=%s)",
                 title,

--- a/kp_registry/server.py
+++ b/kp_registry/server.py
@@ -1,7 +1,8 @@
 """REST wrapper for KP registry SQLite server."""
 from fastapi import FastAPI
+import asyncio
 
-from .routers.kps import registry_router
+from .routers.kps import registry_router, load_from_smartapi, register_endpoints
 
 app = FastAPI(
     title='Knowledge Provider Registry',
@@ -10,3 +11,19 @@ app = FastAPI(
 )
 
 app.include_router(registry_router())
+
+@app.on_event("startup")
+async def build_registry():
+    await load_from_smartapi()
+    #BTE is a KP for our purposes, but it's registered like an ARA, so load_from_smartapi misses it
+    #Special casing it here is perhaps preferable to hacking around and hiding it in load_from_smartapi
+    BTE = [{
+            "_id": None,
+            "title": "Biothings Explorer ReasonerStdAPI",
+            "url": "https://api.bte.ncats.io/v1",
+            "operations": None,
+            "version": None,
+          }]
+    #At the moment this fails because the BTE meta_knowledge_graph does not validate
+    # (it includes "relation: null" on all the edges)
+    #await register_endpoints(BTE)

--- a/kp_registry/server.py
+++ b/kp_registry/server.py
@@ -15,6 +15,7 @@ app.include_router(registry_router())
 @app.on_event("startup")
 async def build_registry():
     await load_from_smartapi()
+    print("blah blah")
     #BTE is a KP for our purposes, but it's registered like an ARA, so load_from_smartapi misses it
     #Special casing it here is perhaps preferable to hacking around and hiding it in load_from_smartapi
     BTE = [{
@@ -24,6 +25,4 @@ async def build_registry():
             "operations": None,
             "version": None,
           }]
-    #At the moment this fails because the BTE meta_knowledge_graph does not validate
-    # (it includes "relation: null" on all the edges)
-    #await register_endpoints(BTE)
+    await register_endpoints(BTE)

--- a/kp_registry/server.py
+++ b/kp_registry/server.py
@@ -7,7 +7,7 @@ from .routers.kps import registry_router, load_from_smartapi, register_endpoints
 app = FastAPI(
     title='Knowledge Provider Registry',
     description='Registry of Translator knowledge providers',
-    version='2.2.0',
+    version='2.3.0',
 )
 
 app.include_router(registry_router())

--- a/kp_registry/server.py
+++ b/kp_registry/server.py
@@ -15,14 +15,15 @@ app.include_router(registry_router())
 @app.on_event("startup")
 async def build_registry():
     await load_from_smartapi()
-    print("blah blah")
-    #BTE is a KP for our purposes, but it's registered like an ARA, so load_from_smartapi misses it
-    #Special casing it here is perhaps preferable to hacking around and hiding it in load_from_smartapi
+    # BTE is a KP for our purposes, but it's registered like an ARA, so load_from_smartapi misses it
+    # Special casing it here is perhaps preferable to hacking around and hiding it in load_from_smartapi
     BTE = [{
-            "_id": None,
-            "title": "Biothings Explorer ReasonerStdAPI",
-            "url": "https://api.bte.ncats.io/v1",
-            "operations": None,
-            "version": None,
-          }]
+        "_id": None,
+        "title": "Biothings Explorer ReasonerStdAPI",
+        "url": "https://api.bte.ncats.io/v1",
+        "operations": None,
+        "version": None,
+    }]
+    # At the moment this fails because the BTE meta_knowledge_graph does not validate
+    # (it includes "relation: null" on all the edges)
     await register_endpoints(BTE)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='kp_registry',
-    version='2.2.0',
+    version='2.3.0',
     author='Patrick Wang',
     author_email='patrick@covar.com',
     url='https://github.com/TranslatorIIPrototypes/kp_registry',


### PR DESCRIPTION
Added a startup event that runs the kp-reload.   
Also included in that startup a registration of BTE.  It's not active right now because BTE mkg is not validating.
Refactored kps a bit to expose the right pieces for these things.
Also stripped '/' off of urls so that adding '/meta_knowledge_graph' doesn't break things (like CHP, which now loads).